### PR TITLE
MGMT-20940: Add Renovate configuration for automated Go and linter updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,78 @@
 {
-    "schedule": ["on Saturday"],
-    "groupName": "Konflux build pipeline",
-    "includePaths": [".tekton/*"],
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
     "commitMessagePrefix": "NO-ISSUE: ",
-    "labels": ["lgtm", "approved", "konflux"]
+    "labels": ["lgtm", "approved"],
+
+    "prHourlyLimit": 0,
+    "prConcurrentLimit": 0,
+
+    "enabledManagers": [
+        "custom.regex",
+        "tekton"
+    ],
+
+    "tekton": {
+        "fileMatch": ["^.tekton/*"]
+    },
+
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^Dockerfile.build$"
+            ],
+            "matchStrings": [
+                "RUN curl .*https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- .* (?<currentValue>.*?)" 
+            ],
+            "depNameTemplate": "github.com/golangci/golangci-lint",
+            "datasourceTemplate": "go"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^Dockerfile$",
+                "^Dockerfile.build$"
+            ],
+            "matchStrings": [
+                "FROM registry.ci.openshift.org/openshift/release:golang-(?<currentValue>[0-9.]+)"
+            ],
+            "depNameTemplate": "registry.ci.openshift.org/openshift/release:golang",
+            "datasourceTemplate": "docker"
+        }
+    ],
+
+    "packageRules": [
+        {
+            "groupName": "Go Builder",
+            "addLabels": ["golang"],
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["registry.ci.openshift.org/openshift/release:golang"],
+            "allowedVersions": "/^[0-9]+\\.[0-9]+$/"
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["registry.ci.openshift.org/openshift/release:golang"],
+            "enabled": false
+        },
+        {
+            "groupName": "Linter",
+            "addLabels": ["linter"],
+            "matchDatasources": ["go"],
+            "matchPackageNames": ["github.com/golangci/golangci-lint"]
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "matchDatasources": ["go"],
+            "matchPackageNames": ["github.com/golangci/golangci-lint"],
+            "enabled": false
+        },
+        {
+            "groupName": "Konflux build pipeline",
+            "addLabels": ["konflux"],
+            "schedule": ["on Saturday"],
+            "matchManagers": ["tekton"]
+        }
+    ]
 }


### PR DESCRIPTION
MGMT-20940:

- Update renovate.json to enable automatic PRs for Go version and golangci-lint version
